### PR TITLE
Add QuickTestRunner with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# QuickTestRunner
+
+QuickTestRunner is a simple tool for executing small test files called `quicktest.kts`.
+
+A `quicktest.kts` file contains top level Kotlin functions. Each function is treated as an
+individual unit test. Files are compiled using the embedded Kotlin compiler and executed
+within the same JVM – the `.kts` extension is only a name and no Kotlin scripting
+frameworks are used.
+
+## Usage
+
+```
+./gradlew run --args='--directory path/to/search'
+```
+
+The program recursively searches the provided directory for every `quicktest.kts` file,
+compiles them and runs all top level functions. A test passes if it completes without
+throwing an exception.
+
+## Building and testing
+
+Run the following command to build the project and execute unit tests:
+
+```
+./gradlew test
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,8 @@ repositories {
 }
 
 dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.1.21")
+    implementation("commons-cli:commons-cli:1.5.0")
     testImplementation(kotlin("test"))
 }
 

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,16 +1,60 @@
 package org.example
 
-//TIP To <b>Run</b> code, press <shortcut actionId="Run"/> or
-// click the <icon src="AllIcons.Actions.Execute"/> icon in the gutter.
-fun main() {
-    val name = "Kotlin"
-    //TIP Press <shortcut actionId="ShowIntentionActions"/> with your caret at the highlighted text
-    // to see how IntelliJ IDEA suggests fixing it.
-    println("Hello, " + name + "!")
+import org.apache.commons.cli.DefaultParser
+import org.apache.commons.cli.Option
+import org.apache.commons.cli.Options
+import org.jetbrains.kotlin.cli.common.CLICompiler
+import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.jetbrains.kotlin.cli.common.ExitCode
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Files
 
-    for (i in 1..5) {
-        //TIP Press <shortcut actionId="Debug"/> to start debugging your code. We have set one <icon src="AllIcons.Debugger.Db_set_breakpoint"/> breakpoint
-        // for you, but you can always add more by pressing <shortcut actionId="ToggleLineBreakpoint"/>.
-        println("i = $i")
+data class TestResult(val file: File, val function: String, val success: Boolean, val error: Throwable?)
+
+fun main(args: Array<String>) {
+    val options = Options().apply {
+        addOption(Option.builder().longOpt("directory").hasArg().desc("Directory to scan").build())
+    }
+    val cmd = DefaultParser().parse(options, args)
+    val dirPath = cmd.getOptionValue("directory", ".")
+    val results = runTests(File(dirPath))
+    results.forEach { result ->
+        if (result.success) {
+            println("PASSED ${'$'}{result.file}:${'$'}{result.function}")
+        } else {
+            println("FAILED ${'$'}{result.file}:${'$'}{result.function} -> ${'$'}{result.error?.message}")
+        }
+    }
+}
+
+fun runTests(root: File): List<TestResult> {
+    val results = mutableListOf<TestResult>()
+    root.walkTopDown().filter { it.name == "quicktest.kts" }.forEach { file ->
+        val outputDir = Files.createTempDirectory("qtcompile").toFile()
+        compileQuickTest(file, outputDir)
+        val className = file.nameWithoutExtension.replaceFirstChar { it.uppercase() } + "Kt"
+        val loader = URLClassLoader(arrayOf(outputDir.toURI().toURL()), ClassLoader.getSystemClassLoader())
+        val clazz = loader.loadClass(className)
+        clazz.declaredMethods.filter { it.parameterCount == 0 }.forEach { method ->
+            try {
+                method.invoke(null)
+                results += TestResult(file, method.name, true, null)
+            } catch (t: Throwable) {
+                results += TestResult(file, method.name, false, t.cause ?: t)
+            }
+        }
+    }
+    return results
+}
+
+fun compileQuickTest(src: File, outputDir: File) {
+    val tempKt = File(outputDir, src.nameWithoutExtension + ".kt")
+    src.copyTo(tempKt, overwrite = true)
+    val cp = System.getProperty("java.class.path")
+    val args = arrayOf("-classpath", cp, "-d", outputDir.absolutePath, tempKt.absolutePath)
+    val exit = CLICompiler.doMainNoExit(K2JVMCompiler(), args)
+    if (exit != ExitCode.OK) {
+        throw RuntimeException("Compilation failed for ${'$'}{src.absolutePath}")
     }
 }

--- a/src/test/kotlin/QuickTestRunnerTest.kt
+++ b/src/test/kotlin/QuickTestRunnerTest.kt
@@ -1,0 +1,26 @@
+package org.example
+
+import kotlin.test.*
+import java.io.File
+
+class QuickTestRunnerTest {
+
+    @Test
+    fun runnerExecutesTests() {
+        val dir = createTempDir(prefix = "qtr")
+        val testFile = File(dir, "quicktest.kts")
+        testFile.writeText(
+            """
+            fun passing() {}
+            fun failing() { throw RuntimeException("boom") }
+            """.trimIndent()
+        )
+
+        val results = runTests(dir)
+        assertEquals(2, results.size)
+        val pass = results.first { it.function == "passing" }
+        val fail = results.first { it.function == "failing" }
+        assertTrue(pass.success)
+        assertFalse(fail.success)
+    }
+}


### PR DESCRIPTION
## Summary
- implement a CLI-based test runner
- compile `quicktest.kts` files using the embedded Kotlin compiler
- run every top level function as a test and report results
- add commons-cli and compiler dependencies
- add a README explaining usage
- add unit test verifying runner

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687b0e25a284832083dbaf682a438174