### PR TITLE
Add logging option for QuickTestRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ frameworks are used.
 ## Usage
 
 ```
-./gradlew run --args='--directory path/to/search'
+./gradlew run --args='--directory path/to/search --log results.xml'
 ```
+
+If the log file ends with `.xml` an XML report is created. If it ends with `.html`,
+the report will be an HTML file.
 
 The program recursively searches the provided directory for every `quicktest.kts` file,
 compiles them and runs all top level functions. A test passes if it completes without

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -15,16 +15,21 @@ data class TestResult(val file: File, val function: String, val success: Boolean
 fun main(args: Array<String>) {
     val options = Options().apply {
         addOption(Option.builder().longOpt("directory").hasArg().desc("Directory to scan").build())
+        addOption(Option.builder().longOpt("log").hasArg().desc("Log file to dump results").build())
     }
     val cmd = DefaultParser().parse(options, args)
     val dirPath = cmd.getOptionValue("directory", ".")
+    val logPath = cmd.getOptionValue("log")
     val results = runTests(File(dirPath))
     results.forEach { result ->
         if (result.success) {
-            println("PASSED ${'$'}{result.file}:${'$'}{result.function}")
+            println("PASSED ${result.file}:${result.function}")
         } else {
-            println("FAILED ${'$'}{result.file}:${'$'}{result.function} -> ${'$'}{result.error?.message}")
+            println("FAILED ${result.file}:${result.function} -> ${result.error?.message}")
         }
+    }
+    if (logPath != null) {
+        writeResults(results, File(logPath))
     }
 }
 
@@ -48,6 +53,62 @@ fun runTests(root: File): List<TestResult> {
     return results
 }
 
+fun writeResults(results: List<TestResult>, logFile: File) {
+    when {
+        logFile.name.endsWith(".xml") -> writeXml(results, logFile)
+        logFile.name.endsWith(".html") -> writeHtml(results, logFile)
+        else -> writePlain(results, logFile)
+    }
+}
+
+fun writeXml(results: List<TestResult>, file: File) {
+    file.printWriter().use { out ->
+        out.println("<tests>")
+        results.forEach { r ->
+            if (r.success) {
+                out.println("  <test file=\"${r.file}\" name=\"${r.function}\" success=\"true\"/>")
+            } else {
+                val stack = r.error?.stackTraceToString()?.xmlEscape()
+                out.println("  <test file=\"${r.file}\" name=\"${r.function}\" success=\"false\">")
+                out.println("    <stacktrace>${stack}</stacktrace>")
+                out.println("  </test>")
+            }
+        }
+        out.println("</tests>")
+    }
+}
+
+fun writeHtml(results: List<TestResult>, file: File) {
+    file.printWriter().use { out ->
+        out.println("<html><body><table>")
+        out.println("<tr><th>File</th><th>Function</th><th>Status</th><th>Stacktrace</th></tr>")
+        results.forEach { r ->
+            val stack = if (r.success) "" else r.error?.stackTraceToString()?.htmlEscape()
+            out.println("<tr><td>${r.file}</td><td>${r.function}</td><td>${if (r.success) "PASSED" else "FAILED"}</td><td><pre>${stack}</pre></td></tr>")
+        }
+        out.println("</table></body></html>")
+    }
+}
+
+fun writePlain(results: List<TestResult>, file: File) {
+    file.printWriter().use { out ->
+        results.forEach { r ->
+            if (r.success) {
+                out.println("PASSED ${r.file}:${r.function}")
+            } else {
+                out.println("FAILED ${r.file}:${r.function}")
+                r.error?.stackTraceToString()?.let { out.println(it) }
+            }
+        }
+    }
+}
+
+fun String.xmlEscape(): String =
+    this.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+fun String.htmlEscape(): String =
+    this.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
 fun compileQuickTest(src: File, outputDir: File) {
     val tempKt = File(outputDir, src.nameWithoutExtension + ".kt")
     src.copyTo(tempKt, overwrite = true)
@@ -55,6 +116,6 @@ fun compileQuickTest(src: File, outputDir: File) {
     val args = arrayOf("-classpath", cp, "-d", outputDir.absolutePath, tempKt.absolutePath)
     val exit = CLICompiler.doMainNoExit(K2JVMCompiler(), args)
     if (exit != ExitCode.OK) {
-        throw RuntimeException("Compilation failed for ${'$'}{src.absolutePath}")
+        throw RuntimeException("Compilation failed for ${src.absolutePath}")
     }
 }

--- a/src/test/kotlin/QuickTestRunnerTest.kt
+++ b/src/test/kotlin/QuickTestRunnerTest.kt
@@ -23,4 +23,28 @@ class QuickTestRunnerTest {
         assertTrue(pass.success)
         assertFalse(fail.success)
     }
+
+    @Test
+    fun writeResultsXmlAndHtml() {
+        val dir = createTempDir(prefix = "qtr")
+        val testFile = File(dir, "quicktest.kts")
+        testFile.writeText(
+            """
+            fun passing() {}
+            fun failing() { throw RuntimeException("boom") }
+            """.trimIndent()
+        )
+
+        val results = runTests(dir)
+
+        val xmlLog = File(dir, "log.xml")
+        writeResults(results, xmlLog)
+        val xmlContent = xmlLog.readText()
+        assertTrue(xmlContent.contains("<test") && xmlContent.contains("stacktrace"))
+
+        val htmlLog = File(dir, "log.html")
+        writeResults(results, htmlLog)
+        val htmlContent = htmlLog.readText()
+        assertTrue(htmlContent.contains("<table>") && htmlContent.contains("RuntimeException"))
+    }
 }


### PR DESCRIPTION
## Summary
- add `--log` command line option
- create xml or html reports depending on log file extension
- test log file generation
- document new option in README

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687b10e6bbdc8320b9d72d5264ca8244