### PR TITLE
Add classpath option to QuickTestRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ frameworks are used.
 ## Usage
 
 ```
-./gradlew run --args='--directory path/to/search --log results.xml'
+./gradlew run --args='--directory path/to/search --log results.xml --classpath "lib/dependency.jar"'
 ```
 
 If the log file ends with `.xml` an XML report is created. If it ends with `.html`,
@@ -28,6 +28,7 @@ You can also run tests directly from Kotlin code using `QuickTestRunner`:
 val results = QuickTestRunner()
     .directory(File("path/to/tests"))
     .logFile(File("results.xml"))
+    .classpath("lib/dependency.jar")
     .run()
 ```
 

--- a/src/main/kotlin/community/kotlin/test/quicktest/QuickTestUtils.kt
+++ b/src/main/kotlin/community/kotlin/test/quicktest/QuickTestUtils.kt
@@ -8,11 +8,10 @@ import java.io.File
 
 /** Utility functions for compiling and reporting quick tests. */
 object QuickTestUtils {
-    fun compileQuickTest(src: File, outputDir: File) {
+    fun compileQuickTest(src: File, outputDir: File, classpath: String = System.getProperty("java.class.path")) {
         val tempKt = File(outputDir, src.nameWithoutExtension + ".kt")
         src.copyTo(tempKt, overwrite = true)
-        val cp = System.getProperty("java.class.path")
-        val args = arrayOf("-classpath", cp, "-d", outputDir.absolutePath, tempKt.absolutePath)
+        val args = arrayOf("-classpath", classpath, "-d", outputDir.absolutePath, tempKt.absolutePath)
         val exit = CLICompiler.doMainNoExit(K2JVMCompiler(), args)
         if (exit != ExitCode.OK) {
             throw RuntimeException("Compilation failed for ${src.absolutePath}")

--- a/src/main/kotlin/org/example/Main.kt
+++ b/src/main/kotlin/org/example/Main.kt
@@ -1,0 +1,7 @@
+package org.example
+
+import community.kotlin.test.quicktest.QuickTestRunner
+
+fun main(args: Array<String>) {
+    QuickTestRunner.main(args)
+}


### PR DESCRIPTION
## Summary
- allow supplying a custom classpath for test compilation and execution
- expose new `--classpath` CLI option
- document the new parameter in README
- support runtime loading of additional classpath entries
- ensure fat jar has an entry point
- test using a custom library

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687b17c18c3c8320bdb38d2a08793099