### PR TITLE
Add classpath option and tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation("commons-cli:commons-cli:1.5.0")
     implementation("org.apache.commons:commons-text:1.10.0")
     testImplementation(kotlin("test"))
+    testImplementation("org.eclipse.jdt:ecj:3.33.0")
 }
 
 tasks.test {
@@ -23,14 +24,14 @@ tasks.test {
 }
 
 application {
-    mainClass.set("org.example.MainKt")
+    mainClass.set("community.kotlin.test.quicktest.QuickTestRunner")
 }
 
 val fatJar by tasks.registering(Jar::class) {
     archiveClassifier.set("all")
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     manifest {
-        attributes["Main-Class"] = "org.example.MainKt"
+        attributes["Main-Class"] = "community.kotlin.test.quicktest.QuickTestRunner"
     }
     from(sourceSets.main.get().output)
     dependsOn(configurations.runtimeClasspath)

--- a/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunner.kt
+++ b/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunner.kt
@@ -11,12 +11,14 @@ import java.nio.file.Files
 class QuickTestRunner {
     private var directory: File = File(".")
     private var logFile: File? = null
+    private var classpath: String? = null
 
     fun directory(dir: File): QuickTestRunner = apply { this.directory = dir }
     fun logFile(file: File): QuickTestRunner = apply { this.logFile = file }
+    fun classpath(cp: String): QuickTestRunner = apply { this.classpath = cp }
 
     fun run(): QuickTestRunResults {
-        val results = runTests(directory)
+        val results = runTests(directory, classpath)
         logFile?.let { QuickTestUtils.writeResults(results, it) }
         return QuickTestRunResults(results)
     }
@@ -27,12 +29,15 @@ class QuickTestRunner {
             val options = Options().apply {
                 addOption(Option.builder().longOpt("directory").hasArg().desc("Directory to scan").build())
                 addOption(Option.builder().longOpt("log").hasArg().desc("Log file to dump results").build())
+                addOption(Option.builder().longOpt("classpath").hasArg().desc("Extra classpath for compiling and running tests").build())
             }
             val cmd = DefaultParser().parse(options, args)
             val dirPath = cmd.getOptionValue("directory", ".")
             val logPath = cmd.getOptionValue("log")
+            val cpArg = cmd.getOptionValue("classpath")
             val runner = QuickTestRunner().directory(File(dirPath))
             if (logPath != null) runner.logFile(File(logPath))
+            if (cpArg != null) runner.classpath(cpArg)
             val results = runner.run()
             results.results.forEach { result ->
                 if (result.success) {
@@ -43,13 +48,19 @@ class QuickTestRunner {
             }
         }
 
-        internal fun runTests(root: File): List<TestResult> {
+        internal fun runTests(root: File, classpath: String? = null): List<TestResult> {
             val results = mutableListOf<TestResult>()
             root.walkTopDown().filter { it.name == "quicktest.kts" }.forEach { file ->
                 val outputDir = Files.createTempDirectory("qtcompile").toFile()
-                QuickTestUtils.compileQuickTest(file, outputDir)
+                QuickTestUtils.compileQuickTest(file, outputDir, classpath)
                 val className = file.nameWithoutExtension.replaceFirstChar { it.uppercase() } + "Kt"
-                val loader = URLClassLoader(arrayOf(outputDir.toURI().toURL()), ClassLoader.getSystemClassLoader())
+                val urls = mutableListOf(outputDir.toURI().toURL())
+                if (!classpath.isNullOrBlank()) {
+                    classpath.split(File.pathSeparator).filter { it.isNotBlank() }.forEach {
+                        urls += File(it).toURI().toURL()
+                    }
+                }
+                val loader = URLClassLoader(urls.toTypedArray(), ClassLoader.getSystemClassLoader())
                 val clazz = loader.loadClass(className)
                 clazz.declaredMethods.filter { it.parameterCount == 0 }.forEach { method ->
                     try {

--- a/src/main/kotlin/community/kotlin/test/quicktest/QuickTestUtils.kt
+++ b/src/main/kotlin/community/kotlin/test/quicktest/QuickTestUtils.kt
@@ -8,10 +8,16 @@ import java.io.File
 
 /** Utility functions for compiling and reporting quick tests. */
 object QuickTestUtils {
-    fun compileQuickTest(src: File, outputDir: File) {
+    fun compileQuickTest(src: File, outputDir: File, classpath: String? = null) {
         val tempKt = File(outputDir, src.nameWithoutExtension + ".kt")
         src.copyTo(tempKt, overwrite = true)
-        val cp = System.getProperty("java.class.path")
+        val cp = buildString {
+            append(System.getProperty("java.class.path"))
+            if (!classpath.isNullOrBlank()) {
+                append(File.pathSeparator)
+                append(classpath)
+            }
+        }
         val args = arrayOf("-classpath", cp, "-d", outputDir.absolutePath, tempKt.absolutePath)
         val exit = CLICompiler.doMainNoExit(K2JVMCompiler(), args)
         if (exit != ExitCode.OK) {

--- a/src/test/kotlin/community/kotlin/test/quicktest/ExtraClasspathTest.kt
+++ b/src/test/kotlin/community/kotlin/test/quicktest/ExtraClasspathTest.kt
@@ -1,0 +1,26 @@
+package community.kotlin.test.quicktest
+
+import kotlin.test.*
+import java.io.File
+
+class ExtraClasspathTest {
+    @Test
+    fun runnerUsesExtraClasspath() {
+        val jar = createMathJar()
+        val dir = createTempDir(prefix = "qtrcp")
+        val testFile = File(dir, "quicktest.kts")
+        testFile.writeText(
+            """
+            fun addTest() { kotlin.test.assertEquals(5, MathOps.add(2,3)) }
+            fun subTest() { kotlin.test.assertEquals(1, MathOps.subtract(3,2)) }
+            fun mulTest() { kotlin.test.assertEquals(6, MathOps.multiply(2,3)) }
+            fun divTest() { kotlin.test.assertEquals(2, MathOps.divide(6,3)) }
+            """.trimIndent()
+        )
+        val results = QuickTestRunner()
+            .directory(dir)
+            .classpath(jar.absolutePath)
+            .run()
+        assertTrue(results.failed().isEmpty(), "All tests should pass")
+    }
+}

--- a/src/test/kotlin/community/kotlin/test/quicktest/TestJarUtils.kt
+++ b/src/test/kotlin/community/kotlin/test/quicktest/TestJarUtils.kt
@@ -1,0 +1,41 @@
+package community.kotlin.test.quicktest
+
+import java.io.File
+import java.io.FileOutputStream
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import javax.tools.StandardLocation
+import org.eclipse.jdt.internal.compiler.tool.EclipseCompiler
+
+fun createMathJar(): File {
+    val tmpDir = kotlin.io.path.createTempDirectory("math").toFile()
+    val srcFile = File(tmpDir, "MathOps.java")
+    srcFile.writeText(
+        """
+        public class MathOps {
+            public static int add(int a,int b){ return a+b; }
+            public static int subtract(int a,int b){ return a-b; }
+            public static int multiply(int a,int b){ return a*b; }
+            public static int divide(int a,int b){ return a/b; }
+        }
+        """.trimIndent()
+    )
+    val classesDir = File(tmpDir, "classes").apply { mkdirs() }
+    val compiler = EclipseCompiler()
+    val fileManager = compiler.getStandardFileManager(null, null, null)
+    fileManager.setLocation(StandardLocation.CLASS_OUTPUT, listOf(classesDir))
+    val units = fileManager.getJavaFileObjects(srcFile)
+    val task = compiler.getTask(null, fileManager, null, null, null, units)
+    if (!task.call()) throw RuntimeException("Compilation failed")
+    fileManager.close()
+    val jarFile = File(tmpDir, "math.jar")
+    JarOutputStream(FileOutputStream(jarFile)).use { jarOut ->
+        classesDir.walkTopDown().filter { it.isFile }.forEach { f ->
+            val entryName = f.relativeTo(classesDir).path.replace(File.separatorChar, '/')
+            jarOut.putNextEntry(JarEntry(entryName))
+            f.inputStream().use { it.copyTo(jarOut) }
+            jarOut.closeEntry()
+        }
+    }
+    return jarFile
+}


### PR DESCRIPTION
## Summary
- update fatjar manifest and main class to QuickTestRunner
- add ability to specify extra classpath for compilation and execution
- provide helper to build a simple math jar using the Eclipse compiler
- test new classpath functionality with the helper jar

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687b196da1488320a6154d62649f8cd3