### PR TITLE
Improve documentation and fix jar entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ frameworks are used.
 
 ## Usage
 
+### Using Gradle
+
 ```
 ./gradlew run --args='--directory path/to/search --log results.xml'
 ```
@@ -20,15 +22,37 @@ The program recursively searches the provided directory for every `quicktest.kts
 compiles them and runs all top level functions. A test passes if it completes without
 throwing an exception.
 
+### Using the fat jar
+
+First build the fat jar:
+
+```
+./gradlew fatJar
+```
+
+Then execute it directly with the same command line options:
+
+```
+java -jar build/libs/QuickTestRunner-1.0-SNAPSHOT-all.jar --directory path/to/search --log results.xml
+```
+
 ### Programmatic usage
 
 You can also run tests directly from Kotlin code using `QuickTestRunner`:
 
-```
+```kotlin
+import community.kotlin.test.quicktest.QuickTestRunner
+import java.io.File
+
 val results = QuickTestRunner()
     .directory(File("path/to/tests"))
     .logFile(File("results.xml"))
     .run()
+
+results.results.forEach { r ->
+    val status = if (r.success) "PASSED" else "FAILED"
+    println("$status ${r.file}:${r.function}")
+}
 ```
 
 `QuickTestRunResults` provides access to the individual `TestResult` entries.

--- a/src/main/kotlin/org/example/Main.kt
+++ b/src/main/kotlin/org/example/Main.kt
@@ -1,0 +1,7 @@
+package org.example
+
+import community.kotlin.test.quicktest.QuickTestRunner
+
+fun main(args: Array<String>) {
+    QuickTestRunner.main(args)
+}


### PR DESCRIPTION
## Summary
- document fat jar usage
- clarify programmatic usage by printing results
- add missing entry point so the fat jar runs

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687b1a27dec88320921c74af2dc48c30