### PR TITLE
Switch QuickTestRunner to Okio

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.2.0")
     implementation("commons-cli:commons-cli:1.5.0")
     implementation("org.apache.commons:commons-text:1.10.0")
+    implementation("com.squareup.okio:okio:3.6.0")
     testImplementation(kotlin("test"))
 }
 

--- a/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunResults.kt
+++ b/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunResults.kt
@@ -1,9 +1,9 @@
 package community.kotlin.test.quicktest
 
-import java.io.File
+import okio.Path
 
 /** Result of running quick tests. */
-data class TestResult(val file: File, val function: String, val success: Boolean, val error: Throwable?)
+data class TestResult(val file: Path, val function: String, val success: Boolean, val error: Throwable?)
 
 class QuickTestRunResults(val results: List<TestResult>) {
     fun passed(): List<TestResult> = results.filter { it.success }

--- a/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunner.kt
+++ b/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunner.kt
@@ -37,22 +37,6 @@ class QuickTestRunner {
         classpath = cp.toList()
     }
 
-    fun directory(dir: File): QuickTestRunner =
-        directory(FileSystem.SYSTEM, dir.toPath().toOkioPath())
-
-    fun logFile(file: File): QuickTestRunner =
-        logFile(FileSystem.SYSTEM, file.toPath().toOkioPath())
-
-    fun classpath(vararg files: File): QuickTestRunner =
-        classpath(FileSystem.SYSTEM, *files.map { it.toPath().toOkioPath() }.toTypedArray())
-
-    fun classpath(cp: String): QuickTestRunner {
-        val paths = cp.split(File.pathSeparator)
-            .filter { it.isNotBlank() }
-            .map { File(it).toPath().toOkioPath() }
-        return classpath(FileSystem.SYSTEM, *paths.toTypedArray())
-    }
-
     fun run(): QuickTestRunResults {
         val results = runTests(dirFs, directory, cpFs, classpath)
         val log = logFile

--- a/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunner.kt
+++ b/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunner.kt
@@ -6,20 +6,57 @@ import org.apache.commons.cli.Options
 import java.io.File
 import java.net.URLClassLoader
 import java.nio.file.Files
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
 
 /** Entry point and core runner for quick tests. */
 class QuickTestRunner {
-    private var directory: File = File(".")
-    private var logFile: File? = null
-    private var classpath: String? = null
+    private var dirFs: FileSystem = FileSystem.SYSTEM
+    private var directory: Path = ".".toPath()
 
-    fun directory(dir: File): QuickTestRunner = apply { this.directory = dir }
-    fun logFile(file: File): QuickTestRunner = apply { this.logFile = file }
-    fun classpath(cp: String): QuickTestRunner = apply { this.classpath = cp }
+    private var logFs: FileSystem = FileSystem.SYSTEM
+    private var logFile: Path? = null
+
+    private var cpFs: FileSystem = FileSystem.SYSTEM
+    private var classpath: List<Path>? = null
+
+    fun directory(fs: FileSystem, dir: Path): QuickTestRunner = apply {
+        dirFs = fs
+        directory = dir
+    }
+
+    fun logFile(fs: FileSystem, file: Path): QuickTestRunner = apply {
+        logFs = fs
+        logFile = file
+    }
+
+    fun classpath(fs: FileSystem, vararg cp: Path): QuickTestRunner = apply {
+        cpFs = fs
+        classpath = cp.toList()
+    }
+
+    fun directory(dir: File): QuickTestRunner =
+        directory(FileSystem.SYSTEM, dir.toPath().toOkioPath())
+
+    fun logFile(file: File): QuickTestRunner =
+        logFile(FileSystem.SYSTEM, file.toPath().toOkioPath())
+
+    fun classpath(vararg files: File): QuickTestRunner =
+        classpath(FileSystem.SYSTEM, *files.map { it.toPath().toOkioPath() }.toTypedArray())
+
+    fun classpath(cp: String): QuickTestRunner {
+        val paths = cp.split(File.pathSeparator)
+            .filter { it.isNotBlank() }
+            .map { File(it).toPath().toOkioPath() }
+        return classpath(FileSystem.SYSTEM, *paths.toTypedArray())
+    }
 
     fun run(): QuickTestRunResults {
-        val results = runTests(directory, classpath)
-        logFile?.let { QuickTestUtils.writeResults(results, it) }
+        val results = runTests(dirFs, directory, cpFs, classpath)
+        val log = logFile
+        if (log != null) QuickTestUtils.writeResults(results, logFs, log)
         return QuickTestRunResults(results)
     }
 
@@ -48,17 +85,19 @@ class QuickTestRunner {
             }
         }
 
-        internal fun runTests(root: File, classpath: String? = null): List<TestResult> {
+        internal fun runTests(dirFs: FileSystem, root: Path, cpFs: FileSystem, cp: List<Path>? = null): List<TestResult> {
             val results = mutableListOf<TestResult>()
-            root.walkTopDown().filter { it.name == "quicktest.kts" }.forEach { file ->
-                val outputDir = Files.createTempDirectory("qtcompile").toFile()
-                val cp = classpath ?: System.getProperty("java.class.path")
-                QuickTestUtils.compileQuickTest(file, outputDir, cp)
-                val className = file.nameWithoutExtension.replaceFirstChar { it.uppercase() } + "Kt"
-                val cpUrls = cp.split(File.pathSeparator)
+            dirFs.listRecursively(root).filter { it.name == "quicktest.kts" }.forEach { file ->
+                val tempDir = Files.createTempDirectory("qtcompile")
+                val outputDir = tempDir.toOkioPath()
+                val classpathStr = cp?.joinToString(File.pathSeparator) { cpFs.canonicalize(it).toString() }
+                    ?: System.getProperty("java.class.path")
+                QuickTestUtils.compileQuickTest(dirFs, file, FileSystem.SYSTEM, outputDir, classpathStr)
+                val className = file.name.substringBeforeLast('.').replaceFirstChar { it.uppercase() } + "Kt"
+                val cpUrls = classpathStr.split(File.pathSeparator)
                     .filter { it.isNotBlank() }
                     .map { File(it).toURI().toURL() }
-                val loaderUrls = arrayOf(outputDir.toURI().toURL()) + cpUrls
+                val loaderUrls = arrayOf(outputDir.toNioPath().toUri().toURL()) + cpUrls.toTypedArray()
                 val loader = URLClassLoader(loaderUrls, ClassLoader.getSystemClassLoader())
                 val clazz = loader.loadClass(className)
                 clazz.declaredMethods.filter { it.parameterCount == 0 }.forEach { method ->

--- a/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunnerExtensions.kt
+++ b/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunnerExtensions.kt
@@ -1,0 +1,22 @@
+package community.kotlin.test.quicktest
+
+import java.io.File
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
+
+/** Convenience extension functions using java.io.File APIs. */
+fun QuickTestRunner.directory(dir: File): QuickTestRunner =
+    directory(FileSystem.SYSTEM, dir.toPath().toOkioPath())
+
+fun QuickTestRunner.logFile(file: File): QuickTestRunner =
+    logFile(FileSystem.SYSTEM, file.toPath().toOkioPath())
+
+fun QuickTestRunner.classpath(vararg files: File): QuickTestRunner =
+    classpath(FileSystem.SYSTEM, *files.map { it.toPath().toOkioPath() }.toTypedArray())
+
+fun QuickTestRunner.classpath(cp: String): QuickTestRunner {
+    val paths = cp.split(File.pathSeparator)
+        .filter { it.isNotBlank() }
+        .map { File(it).toPath().toOkioPath() }
+    return classpath(FileSystem.SYSTEM, *paths.toTypedArray())
+}

--- a/src/test/kotlin/community/kotlin/test/quicktest/QuickTestRunnerPublicApiTest.kt
+++ b/src/test/kotlin/community/kotlin/test/quicktest/QuickTestRunnerPublicApiTest.kt
@@ -2,6 +2,8 @@ package community.kotlin.test.quicktest
 
 import kotlin.test.*
 import java.io.File
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
 
 class QuickTestRunnerPublicApiTest {
     @Test
@@ -56,7 +58,7 @@ class QuickTestRunnerPublicApiTest {
             """.trimIndent()
         )
         val outDir = File(libDir, "out").apply { mkdirs() }
-        QuickTestUtils.compileQuickTest(srcFile, outDir)
+        QuickTestUtils.compileQuickTest(FileSystem.SYSTEM, srcFile.toPath().toOkioPath(), FileSystem.SYSTEM, outDir.toPath().toOkioPath())
         val jarFile = File(libDir, "helper.jar")
         java.util.jar.JarOutputStream(jarFile.outputStream()).use { jar ->
             outDir.walkTopDown().filter { it.isFile && it.extension == "class" }.forEach { cl ->


### PR DESCRIPTION
## Summary
- switch test runner to Okio `FileSystem` and `Path`
- adapt `QuickTestUtils` to work with Okio
- provide File based convenience functions
- update tests for the new API
- add okio library

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687b2373f1fc83208a135a61702bf428