### PR TITLE
Remove obsolete entry point

### DIFF
--- a/src/main/kotlin/org/example/Main.kt
+++ b/src/main/kotlin/org/example/Main.kt
@@ -1,7 +1,0 @@
-package org.example
-
-import community.kotlin.test.quicktest.QuickTestRunner
-
-fun main(args: Array<String>) {
-    QuickTestRunner.main(args)
-}


### PR DESCRIPTION
## Summary
- remove `Main.kt` from `org.example`

## Testing
- `./gradlew test --no-daemon` *(fails: ExtraClasspathTest > runnerUsesExtraClasspath)*

------
https://chatgpt.com/codex/tasks/task_e_687b2c30d42883208a928e4f8e0351fe