### PR TITLE
Add DependsOn annotation

### DIFF
--- a/src/main/kotlin/community/kotlin/test/quicktest/DependsOn.kt
+++ b/src/main/kotlin/community/kotlin/test/quicktest/DependsOn.kt
@@ -1,0 +1,6 @@
+package community.kotlin.test.quicktest
+
+@Target(AnnotationTarget.FILE)
+@Retention(AnnotationRetention.RUNTIME)
+@Repeatable
+annotation class DependsOn(val rule: String)

--- a/src/test/kotlin/community/kotlin/test/quicktest/DependsOnAnnotationTest.kt
+++ b/src/test/kotlin/community/kotlin/test/quicktest/DependsOnAnnotationTest.kt
@@ -1,0 +1,26 @@
+package community.kotlin.test.quicktest
+
+import kotlin.test.*
+import java.io.File
+
+class DependsOnAnnotationTest {
+    @Test
+    fun annotationIsRepeatableAndAccessible() {
+        val dir = createTempDir(prefix = "qtrdep")
+        val testFile = File(dir, "quicktest.kts")
+        testFile.writeText(
+            """
+            @file:DependsOn("ruleA")
+            @file:DependsOn("ruleB")
+
+            import community.kotlin.test.quicktest.DependsOn
+
+            fun sample() {}
+            """.trimIndent()
+        )
+
+        val results = QuickTestRunner().directory(dir).run()
+        assertEquals(1, results.results.size)
+        assertTrue(results.results.first().success)
+    }
+}


### PR DESCRIPTION
## Summary
- add `DependsOn` file-level annotation
- test that annotation can be used repeatedly in `quicktest.kts`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687c2d7546f48320ab38608641ed52ac