### PR TITLE
Add help option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ frameworks are used.
 
 ## Usage
 
+Run `--help` to see all available command line options.
+
 ### Using Gradle
 
 ```

--- a/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunner.kt
+++ b/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunner.kt
@@ -48,11 +48,19 @@ class QuickTestRunner {
         @JvmStatic
         fun main(args: Array<String>) {
             val options = Options().apply {
+                addOption(Option.builder("h")
+                    .longOpt("help")
+                    .desc("Print this help message")
+                    .build())
                 addOption(Option.builder().longOpt("directory").hasArg().desc("Directory to scan").build())
                 addOption(Option.builder().longOpt("log").hasArg().desc("Log file to dump results").build())
                 addOption(Option.builder().longOpt("classpath").hasArg().desc("Extra classpath for compiling and running tests").build())
             }
             val cmd = DefaultParser().parse(options, args)
+            if (cmd.hasOption("help")) {
+                org.apache.commons.cli.HelpFormatter().printHelp("QuickTestRunner", options)
+                return
+            }
             val dirPath = cmd.getOptionValue("directory", ".")
             val logPath = cmd.getOptionValue("log")
             val cp = cmd.getOptionValue("classpath")

--- a/src/test/kotlin/HelpOptionTest.kt
+++ b/src/test/kotlin/HelpOptionTest.kt
@@ -1,0 +1,26 @@
+package org.example
+
+import kotlin.test.*
+import java.io.File
+
+class HelpOptionTest {
+    @Test
+    fun helpOptionShowsUsage() {
+        val jar = File("build/libs/QuickTestRunner-1.0-SNAPSHOT-all.jar")
+        assertTrue(jar.exists(), "Fat jar should be built")
+
+        val process = ProcessBuilder("java", "-jar", jar.absolutePath, "--help")
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText()
+        val exit = process.waitFor()
+
+        val cleaned = output.lines()
+            .filterNot { it.startsWith("warning:") || it.isBlank() }
+            .joinToString("\n").trim()
+
+        assertEquals(0, exit)
+        assertTrue(cleaned.contains("usage"), "Should print usage header")
+        assertTrue(cleaned.contains("--directory"), "Should mention directory option")
+    }
+}


### PR DESCRIPTION
## Summary
- add a `--help` flag to the CLI
- document help flag in README
- test that the fat jar prints usage when called with `--help`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687c7889dfb88320b671a530c5f8494f