### PR TITLE
Add AnnotationPrinter utility

### DIFF
--- a/src/main/kotlin/community/kotlin/psi/leakproof/readonly/AnnotationPrinter.kt
+++ b/src/main/kotlin/community/kotlin/psi/leakproof/readonly/AnnotationPrinter.kt
@@ -1,0 +1,17 @@
+package community.kotlin.psi.leakproof.readonly
+
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtValueArgument
+
+fun printAnnotationName(entry: KtAnnotationEntry) {
+    val name: Name? = entry.shortName
+    println(name?.asString())
+}
+
+fun printArguments(entry: KtAnnotationEntry) {
+    val arg = entry.valueArguments.singleOrNull() as? KtValueArgument
+    val text = arg?.getStringTemplateExpression()?.text
+    println(text)
+}
+


### PR DESCRIPTION
## Summary
- add `AnnotationPrinter` helper to print annotation entry name and single argument text

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687dbc9994d883209e30bd3e3e018e4b