### PR TITLE
Use DependsOn annotations for classpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Run `--help` to see all available command line options.
 ### Using Gradle
 
 ```
-./gradlew run --args='--directory path/to/search --log results.xml --classpath "lib/dependency.jar"'
+./gradlew run --args='--directory path/to/search --workspace path/to/workspace --log results.xml'
 ```
 
 If the log file ends with `.xml` an XML report is created. If it ends with `.html`,
@@ -35,7 +35,7 @@ First build the fat jar:
 Then execute it directly with the same command line options:
 
 ```
-java -jar build/libs/QuickTestRunner-1.0-SNAPSHOT-all.jar --directory path/to/search --log results.xml
+java -jar build/libs/QuickTestRunner-1.0-SNAPSHOT-all.jar --directory path/to/search --workspace path/to/workspace --log results.xml
 ```
 
 ### Programmatic usage
@@ -48,8 +48,8 @@ import java.io.File
 
 val results = QuickTestRunner()
     .directory(File("path/to/tests"))
+    .workspace(File("path/to/workspace"))
     .logFile(File("results.xml"))
-    .classpath("lib/dependency.jar")
     .run()
 
 results.results.forEach { r ->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,9 @@ dependencies {
     implementation("org.apache.commons:commons-text:1.10.0")
     implementation("com.squareup.okio:okio:3.6.0")
     implementation("kompile-cli:kompile-cli:0.0.1")
+    implementation("kompile:build-kotlin-jvm:0.0.1")
     implementation("community.kotlin.psi.annotationutils:community-kotlin-psi-annotationutils:0.0.1")
+    implementation(kotlin("compiler-embeddable"))
     testImplementation(kotlin("test"))
     testImplementation("org.eclipse.jdt:ecj:3.33.0")
 }

--- a/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunner.kt
+++ b/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunner.kt
@@ -5,7 +5,15 @@ import org.apache.commons.cli.Option
 import org.apache.commons.cli.Options
 import java.io.File
 import java.net.URLClassLoader
+import java.net.URI
 import java.nio.file.Files
+import community.kotlin.psi.leakproof.withKtFile
+import kompile.Workspace
+import kompiler.effects.DiagnosticEffect
+import kompiler.effects.DiagnosticSeverity
+import kotlinx.algebraiceffects.Effective
+import kotlinx.algebraiceffects.NotificationEffect
+import kotlin.io.path.createTempFile
 import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toOkioPath
@@ -16,11 +24,12 @@ class QuickTestRunner {
     private var dirFs: FileSystem = FileSystem.SYSTEM
     private var directory: Path = ".".toPath()
 
+    private var workspaceFs: FileSystem = FileSystem.SYSTEM
+    private var workspaceRoot: Path = ".".toPath()
+
     private var logFs: FileSystem = FileSystem.SYSTEM
     private var logFile: Path? = null
 
-    private var cpFs: FileSystem = FileSystem.SYSTEM
-    private var classpath: List<Path>? = null
 
     fun directory(fs: FileSystem, dir: Path): QuickTestRunner = apply {
         dirFs = fs
@@ -32,13 +41,30 @@ class QuickTestRunner {
         logFile = file
     }
 
-    fun classpath(fs: FileSystem, vararg cp: Path): QuickTestRunner = apply {
-        cpFs = fs
-        classpath = cp.toList()
+    fun workspace(fs: FileSystem, root: Path): QuickTestRunner = apply {
+        workspaceFs = fs
+        workspaceRoot = root
     }
 
+    private fun configureProxyFromEnv() {
+        val proxy = System.getenv("HTTP_PROXY") ?: return
+        try {
+            val uri = URI(proxy)
+            val host = uri.host ?: return
+            val port = if (uri.port != -1) uri.port else if (uri.scheme == "https") 443 else 80
+            System.setProperty("http.proxyHost", host)
+            System.setProperty("https.proxyHost", host)
+            System.setProperty("http.proxyPort", port.toString())
+            System.setProperty("https.proxyPort", port.toString())
+        } catch (e: Exception) {
+            System.err.println("Ignoring malformed HTTP_PROXY '$proxy': ${e.message}")
+        }
+    }
+
+
     fun run(): QuickTestRunResults {
-        val results = runTests(dirFs, directory, cpFs, classpath)
+        configureProxyFromEnv()
+        val results = runTests(dirFs, directory, workspaceFs, workspaceRoot)
         val log = logFile
         if (log != null) QuickTestUtils.writeResults(results, logFs, log)
         return QuickTestRunResults(results)
@@ -54,7 +80,7 @@ class QuickTestRunner {
                     .build())
                 addOption(Option.builder().longOpt("directory").hasArg().desc("Directory to scan").build())
                 addOption(Option.builder().longOpt("log").hasArg().desc("Log file to dump results").build())
-                addOption(Option.builder().longOpt("classpath").hasArg().desc("Extra classpath for compiling and running tests").build())
+                addOption(Option.builder().longOpt("workspace").hasArg().desc("Workspace root path").build())
             }
             val cmd = DefaultParser().parse(options, args)
             if (cmd.hasOption("help")) {
@@ -63,10 +89,11 @@ class QuickTestRunner {
             }
             val dirPath = cmd.getOptionValue("directory", ".")
             val logPath = cmd.getOptionValue("log")
-            val cp = cmd.getOptionValue("classpath")
-            val runner = QuickTestRunner().directory(File(dirPath))
+            val wsPath = cmd.getOptionValue("workspace", dirPath)
+            val runner = QuickTestRunner()
+                .directory(File(dirPath))
+                .workspace(File(wsPath))
             if (logPath != null) runner.logFile(File(logPath))
-            if (cp != null) runner.classpath(cp)
             val results = runner.run()
             results.results.forEach { result ->
                 if (result.success) {
@@ -77,14 +104,47 @@ class QuickTestRunner {
             }
         }
 
-        internal fun runTests(dirFs: FileSystem, root: Path, cpFs: FileSystem, cp: List<Path>? = null): List<TestResult> {
+        internal fun runTests(
+            dirFs: FileSystem,
+            root: Path,
+            workspaceFs: FileSystem,
+            workspaceRoot: Path
+        ): List<TestResult> {
             val results = mutableListOf<TestResult>()
             dirFs.listRecursively(root).filter { it.name == "quicktest.kts" }.forEach { file ->
                 val tempDir = Files.createTempDirectory("qtcompile")
                 val outputDir = tempDir.toOkioPath()
-                val classpathStr = cp?.joinToString(File.pathSeparator) { cpFs.canonicalize(it).toString() }
-                    ?: System.getProperty("java.class.path")
-                // TODO: Do compile
+
+                val buildRules = mutableListOf<String>()
+                withKtFile(dirFs.canonicalize(file).toFile()) { ktFile ->
+                    ktFile.annotationEntries.filter { it.shortName!!.identifier == "DependsOn" }.forEach { entry ->
+                        val rule = entry.valueArgumentList!!.arguments.single().text.removeSurrounding("\"")
+                        buildRules += rule
+                    }
+                }
+
+                val cpFiles = buildRules.map {
+                    val wsRoot = workspaceFs.canonicalize(workspaceRoot).toFile()
+                    runBuildRule(wsRoot, it)
+                }
+
+                val runtimeCp = System.getProperty("java.class.path")
+                    .split(File.pathSeparator)
+                    .filter { it.isNotBlank() }
+                    .map { File(it) }
+
+                val classpathStr = (cpFiles.map { it.absolutePath } + runtimeCp.map { it.absolutePath }).joinToString(File.pathSeparator)
+
+                val sourceFile = dirFs.canonicalize(file).toFile()
+                val baseName = file.name.substringBeforeLast('.')
+                val copy = File(outputDir.toFile(), "$baseName.kt")
+                sourceFile.copyTo(copy, overwrite = true)
+                QuickTestUtils.compileTests(
+                    listOf(copy),
+                    cpFiles + runtimeCp,
+                    outputDir.toFile()
+                )
+
                 val className = file.name.substringBeforeLast('.').replaceFirstChar { it.uppercase() } + "Kt"
                 val cpUrls = classpathStr.split(File.pathSeparator)
                     .filter { it.isNotBlank() }
@@ -102,6 +162,26 @@ class QuickTestRunner {
                 }
             }
             return results
+        }
+
+        private fun runBuildRule(workspaceDir: File, rule: String): File {
+            val workspace = Workspace(workspaceDir)
+            val out = kotlin.io.path.createTempFile("qtbuild", null).toFile().apply { delete() }
+            Effective {
+                handler { e: NotificationEffect ->
+                    if (e is DiagnosticEffect && (e.diagnostic.severity == DiagnosticSeverity.ERROR || e.diagnostic.severity == DiagnosticSeverity.WARNING)) {
+                        e.printTinyTrace()
+                    }
+                }
+                workspace.execute(rule, out)
+            }
+            val resultFile = out
+            if (resultFile.isDirectory) {
+                val jar = resultFile.walkTopDown().firstOrNull { it.isFile && it.name.endsWith(".jar") }
+                    ?: throw IllegalStateException("No jar produced by build rule $rule")
+                return jar
+            }
+            return resultFile
         }
     }
 }

--- a/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunnerExtensions.kt
+++ b/src/main/kotlin/community/kotlin/test/quicktest/QuickTestRunnerExtensions.kt
@@ -11,12 +11,5 @@ fun QuickTestRunner.directory(dir: File): QuickTestRunner =
 fun QuickTestRunner.logFile(file: File): QuickTestRunner =
     logFile(FileSystem.SYSTEM, file.toPath().toOkioPath())
 
-fun QuickTestRunner.classpath(vararg files: File): QuickTestRunner =
-    classpath(FileSystem.SYSTEM, *files.map { it.toPath().toOkioPath() }.toTypedArray())
-
-fun QuickTestRunner.classpath(cp: String): QuickTestRunner {
-    val paths = cp.split(File.pathSeparator)
-        .filter { it.isNotBlank() }
-        .map { File(it).toPath().toOkioPath() }
-    return classpath(FileSystem.SYSTEM, *paths.toTypedArray())
-}
+fun QuickTestRunner.workspace(dir: File): QuickTestRunner =
+    workspace(FileSystem.SYSTEM, dir.toPath().toOkioPath())

--- a/src/main/kotlin/community/kotlin/test/quicktest/QuickTestUtils.kt
+++ b/src/main/kotlin/community/kotlin/test/quicktest/QuickTestUtils.kt
@@ -26,7 +26,7 @@ object QuickTestUtils {
         val messageRenderer = MessageRenderer.PLAIN_RELATIVE_PATHS
         val arguments = compiler.createArguments()
         arguments.noStdlib = true
-        arguments.useIR = true
+        arguments.useK2 = false
         arguments.includeRuntime = false
         arguments.classpath = classpath.map { it.absolutePath }.joinToString(":")
         arguments.jvmTarget = "1.8"
@@ -50,6 +50,10 @@ object QuickTestUtils {
         } finally {
             errStream.print(messageRenderer.renderConclusion())
         }
+    }
+
+    fun compileTests(ktFiles: List<File>, classpath: List<File>, destination: File) {
+        compileKotlin(ktFiles, classpath, destination)
     }
 
 

--- a/src/test/kotlin/ExampleProjectTest.kt
+++ b/src/test/kotlin/ExampleProjectTest.kt
@@ -1,0 +1,20 @@
+package org.example
+
+import community.kotlin.test.quicktest.QuickTestRunner
+import community.kotlin.test.quicktest.directory
+import community.kotlin.test.quicktest.workspace
+import kotlin.test.*
+import java.io.File
+
+class ExampleProjectTest {
+    @Test
+    fun quickTestsPass() {
+        val root = File("src/test/resources/ExampleTestProjectWithBuildScriptAndTests")
+        val results = QuickTestRunner()
+            .directory(root)
+            .workspace(root)
+            .run()
+        assertEquals(2, results.results.size)
+        assertTrue(results.failed().isEmpty(), "All quick tests should pass")
+    }
+}


### PR DESCRIPTION
## Summary
- drop CLI classpath flag and related extension helpers
- add `--workspace` flag to set the workspace root
- compile quicktests with runtime and dependency jars
- run quicktests for the example build workspace
- configure HTTP(S) proxy from the `HTTP_PROXY` env var
- remove jackson usage and log malformed HTTP_PROXY
- search build outputs for jars instead of using reflection
- copy `.kts` tests to `.kt` for compilation
- rely on the Kotlin plugin version for the compiler artifact

## Testing
- `./gradlew clean test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687df15fe1548320a894bf44ece84d58