### PR TITLE
Add repository annotation support

### DIFF
--- a/src/test/kotlin/community/kotlin/unittesting/quicktest/RepositoryAnnotationTest.kt
+++ b/src/test/kotlin/community/kotlin/unittesting/quicktest/RepositoryAnnotationTest.kt
@@ -1,0 +1,46 @@
+package org.example
+
+import community.kotlin.unittesting.quicktest.QuickTestRunner
+import community.kotlin.unittesting.quicktest.workspace
+import kotlin.test.*
+import java.io.File
+
+class RepositoryAnnotationTest {
+
+    @Test
+    fun failingRepositoryListsRepositoriesInError() {
+        val root = File("src/test/resources/ExampleProjectWithFakeRepository")
+        val error = assertFailsWith<RuntimeException> {
+            QuickTestRunner()
+                .workspace(root)
+                .run()
+        }
+        assertTrue(error.message!!.contains("org.jsoup:jsoup:1.21.1"))
+        assertTrue(error.message!!.contains("https://fake.repo.example"))
+    }
+
+    @Test
+    fun multipleRepositoriesAreCollected() {
+        val root = File("src/test/resources/ExampleProjectWithMultipleRepositories")
+        val error = assertFailsWith<RuntimeException> {
+            QuickTestRunner()
+                .workspace(root)
+                .run()
+        }
+        assertTrue(error.message!!.contains("https://fake.repo.one"))
+        assertTrue(error.message!!.contains("https://fake.repo.two"))
+    }
+
+    @Test
+    fun defaultsUsedWhenNoRepositorySpecified() {
+        val root = File("src/test/resources/ExampleProjectWithDefaultRepositories")
+        val error = assertFailsWith<RuntimeException> {
+            QuickTestRunner()
+                .workspace(root)
+                .run()
+        }
+        assertTrue(error.message!!.contains("http://kotlin.directory"))
+        assertTrue(error.message!!.contains("https://repo1.maven.org/maven2/"))
+    }
+}
+

--- a/src/test/resources/ExampleProjectWithDefaultRepositories/quicktest.kts
+++ b/src/test/resources/ExampleProjectWithDefaultRepositories/quicktest.kts
@@ -1,0 +1,8 @@
+@file:WithArtifact("org.jsoup:jsoup:1.21.1")
+
+import org.jsoup.Jsoup
+import build.kotlin.withartifact.WithArtifact
+
+fun jsoupTest() {
+    Jsoup.parse("<p>Hello</p>")
+}

--- a/src/test/resources/ExampleProjectWithFakeRepository/quicktest.kts
+++ b/src/test/resources/ExampleProjectWithFakeRepository/quicktest.kts
@@ -1,0 +1,10 @@
+@file:WithRepository("https://fake.repo.example")
+@file:WithArtifact("org.jsoup:jsoup:1.21.1")
+
+import org.jsoup.Jsoup
+import build.kotlin.withartifact.WithArtifact
+import build.kotlin.withartifact.WithRepository
+
+fun jsoupTest() {
+    Jsoup.parse("<p>Hello</p>")
+}

--- a/src/test/resources/ExampleProjectWithMultipleRepositories/quicktest.kts
+++ b/src/test/resources/ExampleProjectWithMultipleRepositories/quicktest.kts
@@ -1,0 +1,11 @@
+@file:WithRepository("https://fake.repo.one")
+@file:WithRepository("https://fake.repo.two")
+@file:WithArtifact("org.jsoup:jsoup:1.21.1")
+
+import org.jsoup.Jsoup
+import build.kotlin.withartifact.WithArtifact
+import build.kotlin.withartifact.WithRepository
+
+fun jsoupTest() {
+    Jsoup.parse("<p>Hello</p>")
+}


### PR DESCRIPTION
## Summary
- support `WithRepository` annotation for specifying maven repositories
- throw helpful error with repository list when fetch fails
- add repository annotation tests

## Testing
- `./gradlew test --no-daemon -q` *(fails: 6 tests completed, 1 failed)*

------
https://chatgpt.com/codex/tasks/task_e_687ec016ea54832099281de8f66d0bb7