### PR TITLE
Adapt tests for QuickTestRunner result handling

### DIFF
--- a/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunner.kt
+++ b/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunner.kt
@@ -94,6 +94,8 @@ class QuickTestRunner {
                 val repositories = getRepositories(file)
                     .ifEmpty { listOf("http://kotlin.directory", "https://repo1.maven.org/maven2/") }
 
+                try {
+
                 val cpFiles = buildRules.flatMap { buildRule ->
                     val wsRoot = workspaceFs.canonicalize(workspaceRoot).toFile()
                     runBuildRule(wsRoot, buildRule, repositories)
@@ -120,6 +122,9 @@ class QuickTestRunner {
                     } catch (t: Throwable) {
                         results += TestResult(file.toOkioPath(), method.name, false, t.cause ?: t)
                     }
+                }
+                } catch (t: Throwable) {
+                    results += TestResult(file.toOkioPath(), "<build>", false, t)
                 }
             }
             return results

--- a/src/test/kotlin/community/kotlin/unittesting/quicktest/RepositoryAnnotationTest.kt
+++ b/src/test/kotlin/community/kotlin/unittesting/quicktest/RepositoryAnnotationTest.kt
@@ -10,37 +10,49 @@ class RepositoryAnnotationTest {
     @Test
     fun failingRepositoryListsRepositoriesInError() {
         val root = File("src/test/resources/ExampleProjectWithFakeRepository")
-        val error = assertFailsWith<RuntimeException> {
-            QuickTestRunner()
-                .workspace(root)
-                .run()
-        }
-        assertTrue(error.message!!.contains("org.jsoup:jsoup:1.21.1"))
-        assertTrue(error.message!!.contains("https://fake.repo.example"))
+        val results = QuickTestRunner()
+            .workspace(root)
+            .run()
+
+        val failures = results.failed()
+        assertTrue(failures.isNotEmpty(), "Expected the quick test to fail")
+        val message = failures.first().error?.message
+
+        assertNotNull(message)
+        assertTrue(message!!.contains("org.jsoup:jsoup:1.21.1"))
+        assertTrue(message.contains("https://fake.repo.example"))
     }
 
     @Test
     fun multipleRepositoriesAreCollected() {
         val root = File("src/test/resources/ExampleProjectWithMultipleRepositories")
-        val error = assertFailsWith<RuntimeException> {
-            QuickTestRunner()
-                .workspace(root)
-                .run()
-        }
-        assertTrue(error.message!!.contains("https://fake.repo.one"))
-        assertTrue(error.message!!.contains("https://fake.repo.two"))
+        val results = QuickTestRunner()
+            .workspace(root)
+            .run()
+
+        val failures = results.failed()
+        assertTrue(failures.isNotEmpty(), "Expected the quick test to fail")
+        val message = failures.first().error?.message
+
+        assertNotNull(message)
+        assertTrue(message!!.contains("https://fake.repo.one"))
+        assertTrue(message.contains("https://fake.repo.two"))
     }
 
     @Test
     fun defaultsUsedWhenNoRepositorySpecified() {
         val root = File("src/test/resources/ExampleProjectWithDefaultRepositories")
-        val error = assertFailsWith<RuntimeException> {
-            QuickTestRunner()
-                .workspace(root)
-                .run()
-        }
-        assertTrue(error.message!!.contains("http://kotlin.directory"))
-        assertTrue(error.message!!.contains("https://repo1.maven.org/maven2/"))
+        val results = QuickTestRunner()
+            .workspace(root)
+            .run()
+
+        val failures = results.failed()
+        assertTrue(failures.isNotEmpty(), "Expected the quick test to fail")
+        val message = failures.first().error?.message
+
+        assertNotNull(message)
+        assertTrue(message!!.contains("http://kotlin.directory"))
+        assertTrue(message.contains("https://repo1.maven.org/maven2/"))
     }
 }
 


### PR DESCRIPTION
## Summary
- adjust RepositoryAnnotationTest to inspect `QuickTestRunResults`
- handle build errors in `QuickTestRunner` so test execution continues

## Testing
- `./gradlew test --no-daemon` *(fails: ExampleProjectTest.quickTestsPass)*

------
https://chatgpt.com/codex/tasks/task_e_687ef59656ac83209217c50107c6ac07