### PR TITLE
Introduce TestStatus filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ You can also run tests directly from Kotlin code using `QuickTestRunner`:
 
 ```kotlin
 import community.kotlin.unittesting.quicktest.QuickTestRunner
+import community.kotlin.unittesting.quicktest.TestStatus
 import java.io.File
 
 val results = QuickTestRunner()
@@ -54,12 +55,13 @@ val results = QuickTestRunner()
     .run()
 
 results.results.forEach { r ->
-    val status = if (r.success) "PASSED" else "FAILED"
+    val status = if (r.status == TestStatus.SUCCESS) "PASSED" else "FAILED"
     println("$status ${r.file}:${r.function}")
 }
 ```
 
 `QuickTestRunResults` provides access to the individual `TestResult` entries.
+Use `getResults()` to optionally filter results by `TestStatus`.
 
 ## Building and testing
 

--- a/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunResults.kt
+++ b/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunResults.kt
@@ -2,10 +2,22 @@ package community.kotlin.unittesting.quicktest
 
 import okio.Path
 
+/** Status of a single test execution. */
+enum class TestStatus {
+    SUCCESS,
+    FAILURE,
+    /** A unit test which exists and can be reenabled, but which is currently set to not run. */
+    DISABLED,
+    /** The test was forcibly terminated due to external factors. */
+    ABORTED,
+    /** The unit test is running but has not yet completed. */
+    RUNNING
+}
+
 /** Result of running quick tests. */
-data class TestResult(val file: Path, val function: String, val success: Boolean, val error: Throwable?)
+data class TestResult(val file: Path, val function: String, val status: TestStatus, val error: Throwable?)
 
 class QuickTestRunResults(val results: List<TestResult>) {
-    fun passed(): List<TestResult> = results.filter { it.success }
-    fun failed(): List<TestResult> = results.filter { !it.success }
+    fun getResults(status: TestStatus? = null): List<TestResult> =
+        status?.let { results.filter { r -> r.status == it } } ?: results
 }

--- a/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunner.kt
+++ b/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunner.kt
@@ -21,6 +21,8 @@ import okio.Path.Companion.toOkioPath
 import okio.Path.Companion.toPath
 import okio.buffer
 
+import community.kotlin.unittesting.quicktest.TestStatus
+
 /** Entry point and core runner for quick tests. */
 class QuickTestRunner {
 
@@ -70,7 +72,7 @@ class QuickTestRunner {
             if (logPath != null) runner.logFile(File(logPath))
             val results = runner.run()
             results.results.forEach { result ->
-                if (result.success) {
+                if (result.status == TestStatus.SUCCESS) {
                     println("PASSED ${result.file}:${result.function}")
                 } else {
                     println("FAILED ${result.file}:${result.function} -> ${result.error?.message}")
@@ -118,13 +120,13 @@ class QuickTestRunner {
                 clazz.declaredMethods.filter { it.parameterCount == 0 }.forEach { method ->
                     try {
                         method.invoke(null)
-                        results += TestResult(file.toOkioPath(), method.name, true, null)
+                        results += TestResult(file.toOkioPath(), method.name, TestStatus.SUCCESS, null)
                     } catch (t: Throwable) {
-                        results += TestResult(file.toOkioPath(), method.name, false, t.cause ?: t)
+                        results += TestResult(file.toOkioPath(), method.name, TestStatus.FAILURE, t.cause ?: t)
                     }
                 }
                 } catch (t: Throwable) {
-                    results += TestResult(file.toOkioPath(), "<build>", false, t)
+                    results += TestResult(file.toOkioPath(), "<build>", TestStatus.FAILURE, t)
                 }
             }
             return results

--- a/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestUtils.kt
+++ b/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestUtils.kt
@@ -12,6 +12,7 @@ import org.apache.commons.text.StringEscapeUtils
 import okio.FileSystem
 import okio.Path
 import okio.buffer
+import community.kotlin.unittesting.quicktest.TestStatus
 import org.jetbrains.kotlin.cli.common.arguments.validateArguments
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.config.Services
@@ -65,7 +66,7 @@ object QuickTestUtils {
         fs.sink(file).buffer().use { out ->
             out.writeUtf8("<tests>\n")
             results.forEach { r ->
-                if (r.success) {
+                if (r.status == TestStatus.SUCCESS) {
                     out.writeUtf8("  <test file=\"${r.file}\" name=\"${r.function}\" success=\"true\"/>\n")
                 } else {
                     val stack = r.error?.stackTraceToString()?.xmlEscape()
@@ -83,8 +84,9 @@ object QuickTestUtils {
             out.writeUtf8("<html><body><table>\n")
             out.writeUtf8("<tr><th>File</th><th>Function</th><th>Status</th><th>Stacktrace</th></tr>\n")
             results.forEach { r ->
-                val stack = if (r.success) "" else r.error?.stackTraceToString()?.htmlEscape()
-                out.writeUtf8("<tr><td>${r.file}</td><td>${r.function}</td><td>${if (r.success) "PASSED" else "FAILED"}</td><td><pre>${stack}</pre></td></tr>\n")
+                val stack = if (r.status == TestStatus.SUCCESS) "" else r.error?.stackTraceToString()?.htmlEscape()
+                val status = if (r.status == TestStatus.SUCCESS) "PASSED" else "FAILED"
+                out.writeUtf8("<tr><td>${r.file}</td><td>${r.function}</td><td>${status}</td><td><pre>${stack}</pre></td></tr>\n")
             }
             out.writeUtf8("</table></body></html>\n")
         }
@@ -93,7 +95,7 @@ object QuickTestUtils {
     private fun writePlain(results: List<TestResult>, fs: FileSystem, file: Path) {
         fs.sink(file).buffer().use { out ->
             results.forEach { r ->
-                if (r.success) {
+                if (r.status == TestStatus.SUCCESS) {
                     out.writeUtf8("PASSED ${r.file}:${r.function}\n")
                 } else {
                     out.writeUtf8("FAILED ${r.file}:${r.function}\n")

--- a/src/test/kotlin/community/kotlin/unittesting/quicktest/ExampleProjectTest.kt
+++ b/src/test/kotlin/community/kotlin/unittesting/quicktest/ExampleProjectTest.kt
@@ -1,6 +1,7 @@
 package org.example
 
 import community.kotlin.unittesting.quicktest.QuickTestRunner
+import community.kotlin.unittesting.quicktest.TestStatus
 import community.kotlin.unittesting.quicktest.workspace
 import kotlin.test.*
 import java.io.File
@@ -13,6 +14,6 @@ class ExampleProjectTest {
             .workspace(root)
             .run()
         assertEquals(3, results.results.size)
-        assertTrue(results.failed().isEmpty(), "All quick tests should pass")
+        assertTrue(results.getResults(TestStatus.FAILURE).isEmpty(), "All quick tests should pass")
     }
 }

--- a/src/test/kotlin/community/kotlin/unittesting/quicktest/RepositoryAnnotationTest.kt
+++ b/src/test/kotlin/community/kotlin/unittesting/quicktest/RepositoryAnnotationTest.kt
@@ -1,6 +1,7 @@
 package org.example
 
 import community.kotlin.unittesting.quicktest.QuickTestRunner
+import community.kotlin.unittesting.quicktest.TestStatus
 import community.kotlin.unittesting.quicktest.workspace
 import kotlin.test.*
 import java.io.File
@@ -14,7 +15,7 @@ class RepositoryAnnotationTest {
             .workspace(root)
             .run()
 
-        val failures = results.failed()
+        val failures = results.getResults(TestStatus.FAILURE)
         assertTrue(failures.isNotEmpty(), "Expected the quick test to fail")
         val message = failures.first().error?.message
 
@@ -30,7 +31,7 @@ class RepositoryAnnotationTest {
             .workspace(root)
             .run()
 
-        val failures = results.failed()
+        val failures = results.getResults(TestStatus.FAILURE)
         assertTrue(failures.isNotEmpty(), "Expected the quick test to fail")
         val message = failures.first().error?.message
 
@@ -46,9 +47,9 @@ class RepositoryAnnotationTest {
             .workspace(root)
             .run()
 
-        val failures = results.failed()
+        val failures = results.getResults(TestStatus.FAILURE)
         assertTrue(failures.isEmpty(), "Expected no failures")
-        assertTrue(results.passed().size == 1, "Expected the quick test to pass")
+        assertTrue(results.getResults(TestStatus.SUCCESS).size == 1, "Expected the quick test to pass")
     }
 }
 


### PR DESCRIPTION
## Summary
- add `TestStatus` enum and use it in `TestResult`
- replace `passed()`/`failed()` with `getResults()`
- adjust `QuickTestRunner` and `QuickTestUtils` to use the new enum
- update tests and README for the new API

## Testing
- `./gradlew test` *(fails: ExampleProjectTest, RepositoryAnnotationTest)*

------
https://chatgpt.com/codex/tasks/task_e_687efe7d67a08320a52883c427f3b518