### PR TITLE
Use Java 21 toolchain

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     application
 }
 
+kotlin {
+    jvmToolchain(21)
+}
+
 group = "community.kotlin.unittesting.quicktest"
 version = "1.0-SNAPSHOT"
 


### PR DESCRIPTION
## Summary
- specify Kotlin JVM toolchain so the project compiles with Java 21

## Testing
- `./gradlew test --console=plain --no-daemon` *(fails: ExampleProjectTest, RepositoryAnnotationTest)*

------
https://chatgpt.com/codex/tasks/task_e_687f1c7b15648320b1beda26474a6b34