### PR TITLE
Add result summary and verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ frameworks are used.
 ## Usage
 
 Run `--help` to see all available command line options.
+By default only failing tests are printed and a summary is shown.
+Use `--verbose` to print results for all tests.
 
 ### Using Gradle
 

--- a/src/test/kotlin/ResultSummaryTest.kt
+++ b/src/test/kotlin/ResultSummaryTest.kt
@@ -1,0 +1,71 @@
+package org.example
+
+import kotlin.test.*
+import java.io.File
+import java.net.URI
+
+class ResultSummaryTest {
+    private val jar = File("build/libs/QuickTestRunner-1.0-SNAPSHOT-all.jar")
+
+    private fun parseProxy(env: String): Pair<String, String>? {
+        val value = System.getenv(env) ?: System.getenv(env.lowercase()) ?: return null
+        val formatted = if ("://" in value) value else "http://$value"
+        return try {
+            val uri = URI(formatted)
+            val host = uri.host ?: return null
+            val port = if (uri.port == -1) "80" else uri.port.toString()
+            host to port
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun proxyArgs(): List<String> {
+        val args = mutableListOf<String>()
+        parseProxy("HTTP_PROXY")?.let { (h, p) ->
+            args += "-Dhttp.proxyHost=$h"
+            args += "-Dhttp.proxyPort=$p"
+        }
+        parseProxy("HTTPS_PROXY")?.let { (h, p) ->
+            args += "-Dhttps.proxyHost=$h"
+            args += "-Dhttps.proxyPort=$p"
+        }
+        return args
+    }
+
+    @Test
+    fun allTestsPassSummary() {
+        assertTrue(jar.exists(), "Fat jar should be built")
+        val root = File("src/test/resources/ExampleTestProjectWithBuildScriptAndTests")
+        val cmd = mutableListOf("java") + proxyArgs() + listOf("-jar", jar.absolutePath, "--workspace", root.absolutePath)
+        val process = ProcessBuilder(cmd).redirectErrorStream(true).start()
+        val output = process.inputStream.bufferedReader().readText()
+        val exit = process.waitFor()
+        assertEquals(0, exit)
+        assertTrue(output.contains("ALL TESTS PASSED"), "Should report all tests passed")
+    }
+
+    @Test
+    fun failingTestsSummaryAndExitCode() {
+        assertTrue(jar.exists(), "Fat jar should be built")
+        val root = File("src/test/resources/ExampleProjectWithFakeRepository")
+        val cmd = mutableListOf("java") + proxyArgs() + listOf("-jar", jar.absolutePath, "--workspace", root.absolutePath)
+        val process = ProcessBuilder(cmd).redirectErrorStream(true).start()
+        val output = process.inputStream.bufferedReader().readText()
+        val exit = process.waitFor()
+        assertNotEquals(0, exit)
+        assertTrue(output.contains("TEST FAILURES"), "Should report failures")
+    }
+
+    @Test
+    fun verbosePrintsPassingTests() {
+        assertTrue(jar.exists(), "Fat jar should be built")
+        val root = File("src/test/resources/ExampleTestProjectWithBuildScriptAndTests")
+        val cmd = mutableListOf("java") + proxyArgs() + listOf("-jar", jar.absolutePath, "--workspace", root.absolutePath, "--verbose")
+        val process = ProcessBuilder(cmd).redirectErrorStream(true).start()
+        val output = process.inputStream.bufferedReader().readText()
+        process.waitFor()
+        val passedCount = output.lines().count { it.trim().startsWith("PASSED") }
+        assertEquals(3, passedCount, "Verbose output should include all passing tests")
+    }
+}


### PR DESCRIPTION
## Summary
- print a summary after running tests
- add `--verbose` CLI option to show all tests
- exit with non-zero status when there are failures
- document new behaviour
- test CLI result summary and verbose flag

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687f2310372083208558fb193a5b7b06