### PR TITLE
Enable Gradle JDK 17 toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Use `getResults()` to optionally filter results by `TestStatus`.
 
 ## Building and testing
 
+The project is built with JDK 17 using Gradle's toolchain support. Gradle will
+automatically download the JDK if it is not already installed.
+
 Run the following command to build the project and execute unit tests:
 
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,16 @@ plugins {
     application
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
 group = "community.kotlin.unittesting.quicktest"
 version = "1.0-SNAPSHOT"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+org.gradle.java.installations.auto-download=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,11 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+plugins {
+}
+
 rootProject.name = "QuickTestRunner"


### PR DESCRIPTION
## Summary
- configure Java and Kotlin to use JDK 17
- allow Gradle to auto-download the toolchain
- add plugin management block
- document the JDK requirement in README

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687f23907ab48320a47a9370774fa33e