### PR TITLE
Show verbose failure stacktrace

### DIFF
--- a/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunner.kt
+++ b/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunner.kt
@@ -80,6 +80,9 @@ class QuickTestRunner {
                     println("PASSED ${result.file}:${result.function}")
                 } else {
                     println("FAILED ${result.file}:${result.function} -> ${result.error?.message}")
+                    if (verbose) {
+                        result.error?.printStackTrace()
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- show stack traces for failing tests when verbose mode is enabled

## Testing
- `./gradlew test` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f28f4a9188320829f0c07cc6319b8