### PR TITLE
Show fully qualified name for failing tests

### DIFF
--- a/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunResults.kt
+++ b/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunResults.kt
@@ -15,7 +15,13 @@ enum class TestStatus {
 }
 
 /** Result of running quick tests. */
-data class TestResult(val file: Path, val function: String, val status: TestStatus, val error: Throwable?)
+data class TestResult(
+    val file: Path,
+    val function: String,
+    val packageName: String,
+    val status: TestStatus,
+    val error: Throwable?
+)
 
 class QuickTestRunResults(val results: List<TestResult>) {
     fun getResults(status: TestStatus? = null): List<TestResult> =

--- a/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunner.kt
+++ b/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunner.kt
@@ -76,10 +76,11 @@ class QuickTestRunner {
             val results = runner.run()
             val outputResults = if (verbose) results.results else results.results.filter { it.status != TestStatus.SUCCESS }
             outputResults.forEach { result ->
+                val qualifiedName = if (result.packageName.isNotEmpty()) "${result.packageName}.${result.function}" else result.function
                 if (result.status == TestStatus.SUCCESS) {
-                    println("PASSED ${result.file}:${result.function}")
+                    println("PASSED $qualifiedName")
                 } else {
-                    println("FAILED ${result.file}:${result.function} -> ${result.error?.message}")
+                    println("FAILED $qualifiedName -> ${result.error?.message}")
                     if (verbose) {
                         result.error?.printStackTrace()
                     }
@@ -110,6 +111,12 @@ class QuickTestRunner {
                         out.writeAll(src)
                     }
                 }
+                val pkgRegex = Regex("^\\s*package\\s+([\\w.]+)")
+                val packageName = workspaceFs.source(file.toOkioPath()).buffer().use { src ->
+                    src.readUtf8().lineSequence().firstOrNull { line -> pkgRegex.containsMatchIn(line) }?.let { line ->
+                        pkgRegex.find(line)?.groupValues?.get(1)
+                    } ?: ""
+                }
                 val buildRules = getBuildRules(file)
                 val repositories = getRepositories(file)
                     .ifEmpty { listOf("http://kotlin.directory/", "https://repo1.maven.org/maven2/") }
@@ -122,20 +129,21 @@ class QuickTestRunner {
                     } + getBuildAnnotationsJar()
 
                 QuickTestUtils.compileKotlin(listOf(ktPath.toFile()), cpFiles, outputDir.toNioPath().toFile())
-                val className = file.name.substringBeforeLast('.').replaceFirstChar { it.uppercase() } + "Kt"
+                val baseClassName = file.name.substringBeforeLast('.').replaceFirstChar { it.uppercase() } + "Kt"
+                val className = if (packageName.isNotEmpty()) "$packageName.$baseClassName" else baseClassName
                 val loaderUrls = arrayOf(outputDir.toNioPath().toUri().toURL()) + cpFiles.map { it.toURI().toURL() }.toTypedArray()
                 val loader = URLClassLoader(loaderUrls, ClassLoader.getSystemClassLoader())
                 val clazz = loader.loadClass(className)
                 clazz.declaredMethods.filter { it.parameterCount == 0 }.forEach { method ->
                     try {
                         method.invoke(null)
-                        results += TestResult(file.toOkioPath(), method.name, TestStatus.SUCCESS, null)
+                        results += TestResult(file.toOkioPath(), method.name, packageName, TestStatus.SUCCESS, null)
                     } catch (t: Throwable) {
-                        results += TestResult(file.toOkioPath(), method.name, TestStatus.FAILURE, t.cause ?: t)
+                        results += TestResult(file.toOkioPath(), method.name, packageName, TestStatus.FAILURE, t.cause ?: t)
                     }
                 }
                 } catch (t: Throwable) {
-                    results += TestResult(file.toOkioPath(), "<build>", TestStatus.FAILURE, t)
+                    results += TestResult(file.toOkioPath(), "<build>", packageName, TestStatus.FAILURE, t)
                 }
             }
             return results

--- a/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestUtils.kt
+++ b/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestUtils.kt
@@ -66,11 +66,12 @@ object QuickTestUtils {
         fs.sink(file).buffer().use { out ->
             out.writeUtf8("<tests>\n")
             results.forEach { r ->
+                val qualifiedName = if (r.packageName.isNotEmpty()) "${r.packageName}.${r.function}" else r.function
                 if (r.status == TestStatus.SUCCESS) {
-                    out.writeUtf8("  <test file=\"${r.file}\" name=\"${r.function}\" success=\"true\"/>\n")
+                    out.writeUtf8("  <test file=\"${r.file}\" name=\"${qualifiedName}\" success=\"true\"/>\n")
                 } else {
                     val stack = r.error?.stackTraceToString()?.xmlEscape()
-                    out.writeUtf8("  <test file=\"${r.file}\" name=\"${r.function}\" success=\"false\">\n")
+                    out.writeUtf8("  <test file=\"${r.file}\" name=\"${qualifiedName}\" success=\"false\">\n")
                     out.writeUtf8("    <stacktrace>${stack}</stacktrace>\n")
                     out.writeUtf8("  </test>\n")
                 }
@@ -86,7 +87,8 @@ object QuickTestUtils {
             results.forEach { r ->
                 val stack = if (r.status == TestStatus.SUCCESS) "" else r.error?.stackTraceToString()?.htmlEscape()
                 val status = if (r.status == TestStatus.SUCCESS) "PASSED" else "FAILED"
-                out.writeUtf8("<tr><td>${r.file}</td><td>${r.function}</td><td>${status}</td><td><pre>${stack}</pre></td></tr>\n")
+                val qualifiedName = if (r.packageName.isNotEmpty()) "${r.packageName}.${r.function}" else r.function
+                out.writeUtf8("<tr><td>${r.file}</td><td>${qualifiedName}</td><td>${status}</td><td><pre>${stack}</pre></td></tr>\n")
             }
             out.writeUtf8("</table></body></html>\n")
         }
@@ -95,10 +97,11 @@ object QuickTestUtils {
     private fun writePlain(results: List<TestResult>, fs: FileSystem, file: Path) {
         fs.sink(file).buffer().use { out ->
             results.forEach { r ->
+                val qualifiedName = if (r.packageName.isNotEmpty()) "${r.packageName}.${r.function}" else r.function
                 if (r.status == TestStatus.SUCCESS) {
-                    out.writeUtf8("PASSED ${r.file}:${r.function}\n")
+                    out.writeUtf8("PASSED $qualifiedName\n")
                 } else {
-                    out.writeUtf8("FAILED ${r.file}:${r.function}\n")
+                    out.writeUtf8("FAILED $qualifiedName\n")
                     r.error?.stackTraceToString()?.let { out.writeUtf8(it + "\n") }
                 }
             }


### PR DESCRIPTION
## Summary
- include package name in `TestResult`
- parse package names from `test.kts`
- print fully qualified test names in CLI and log writers

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687f393e76908320959750c40db40ce0