### PR TITLE
Add build annotations dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation("kompile-cli:kompile-cli:0.0.1")
     implementation("community.kotlin.psi.annotationutils:community-kotlin-psi-annotationutils:0.0.1")
     implementation("build.kotlin.withartifact:build-kotlin-withartifact:0.0.1")
+    implementation("build.kotlin.annotations:build-kotlin-annotations:0.0.1")
     implementation("io.get-coursier:interface:1.0.28")
     testImplementation(kotlin("test"))
     testImplementation("org.eclipse.jdt:ecj:3.33.0")

--- a/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunner.kt
+++ b/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunner.kt
@@ -155,12 +155,23 @@ class QuickTestRunner {
 
 // TODO: Should provide annotations from an embedded jar (instead of fetching from maven) in order to enable offline execution.
 private fun getBuildAnnotationsJar(): List<File> {
-    val parts = "build.kotlin.withartifact:build-kotlin-withartifact:0.0.1".split(":")
-    val dep = Dependency.of(parts[0], parts[1], parts[2])
+    val withArtifact = Dependency.of(
+        "build.kotlin.withartifact",
+        "build-kotlin-withartifact",
+        "0.0.1"
+    )
+    val annotations = Dependency.of(
+        "build.kotlin.annotations",
+        "build-kotlin-annotations",
+        "0.0.1"
+    )
     val fetch = Fetch.create()
-    val coursierRepositories = listOf("http://kotlin.directory").map { repoUrl -> MavenRepository.of(repoUrl) }.toTypedArray()
+    val coursierRepositories = listOf("http://kotlin.directory")
+        .map { repoUrl -> MavenRepository.of(repoUrl) }
+        .toTypedArray()
     fetch.withRepositories(*coursierRepositories)
-    fetch.withDependencies(dep.withTransitive(false))
+    fetch.withDependencies(withArtifact.withTransitive(false))
+    fetch.addDependencies(annotations.withTransitive(false))
     return fetch.fetch()
 }
 


### PR DESCRIPTION
## Summary
- add `build-kotlin-annotations` artifact to Gradle dependencies
- fetch the annotations jar in QuickTestRunner

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687f48388bc88320832354d83a625d0f