### PR TITLE
Support disabled tests

### DIFF
--- a/src/test/kotlin/ResultSummaryTest.kt
+++ b/src/test/kotlin/ResultSummaryTest.kt
@@ -68,4 +68,29 @@ class ResultSummaryTest {
         val passedCount = output.lines().count { it.trim().startsWith("PASSED") }
         assertEquals(3, passedCount, "Verbose output should include all passing tests")
     }
+
+    @Test
+    fun disabledTestsSummaryAndOutput() {
+        assertTrue(jar.exists(), "Fat jar should be built")
+        val root = File("src/test/resources/ExampleProjectWithDisabled")
+        val cmd = mutableListOf("java") + proxyArgs() + listOf("-jar", jar.absolutePath, "--workspace", root.absolutePath)
+        val process = ProcessBuilder(cmd).redirectErrorStream(true).start()
+        val output = process.inputStream.bufferedReader().readText()
+        val exit = process.waitFor()
+        assertEquals(0, exit)
+        assertTrue(output.contains("ALL TESTS PASSED"))
+        assertTrue(output.contains("1 unit tests disabled"))
+        assertFalse(output.contains("disabledTest"), "Disabled test name should not be printed")
+    }
+
+    @Test
+    fun verbosePrintsDisabledTests() {
+        assertTrue(jar.exists(), "Fat jar should be built")
+        val root = File("src/test/resources/ExampleProjectWithDisabled")
+        val cmd = mutableListOf("java") + proxyArgs() + listOf("-jar", jar.absolutePath, "--workspace", root.absolutePath, "--verbose")
+        val process = ProcessBuilder(cmd).redirectErrorStream(true).start()
+        val output = process.inputStream.bufferedReader().readText()
+        process.waitFor()
+        assertTrue(output.lines().any { it.trim() == "DISABLED disabledTest" }, "Verbose output should include disabled tests")
+    }
 }

--- a/src/test/kotlin/community/kotlin/unittesting/quicktest/DisabledAnnotationTest.kt
+++ b/src/test/kotlin/community/kotlin/unittesting/quicktest/DisabledAnnotationTest.kt
@@ -1,0 +1,21 @@
+package org.example
+
+import community.kotlin.unittesting.quicktest.QuickTestRunner
+import community.kotlin.unittesting.quicktest.TestStatus
+import community.kotlin.unittesting.quicktest.workspace
+import kotlin.test.*
+import java.io.File
+
+class DisabledAnnotationTest {
+    @Test
+    fun disabledTestsAreNotRun() {
+        val root = File("src/test/resources/ExampleProjectWithDisabled")
+        val results = QuickTestRunner()
+            .workspace(root)
+            .run()
+        assertEquals(2, results.results.size)
+        assertTrue(results.getResults(TestStatus.FAILURE).isEmpty(), "No failures expected")
+        assertEquals(1, results.getResults(TestStatus.DISABLED).size, "One test should be disabled")
+        assertEquals(1, results.getResults(TestStatus.SUCCESS).size, "One test should run")
+    }
+}

--- a/src/test/resources/ExampleProjectWithDisabled/test.kts
+++ b/src/test/resources/ExampleProjectWithDisabled/test.kts
@@ -1,0 +1,14 @@
+@file:WithArtifact("org.jsoup:jsoup:1.21.1")
+
+import org.jsoup.Jsoup
+import build.kotlin.withartifact.WithArtifact
+import build.kotlin.annotations.Disabled
+
+fun enabledTest() {
+    Jsoup.parse("<p>Hello</p>")
+}
+
+@Disabled("not ready")
+fun disabledTest() {
+    throw Error("Should not run")
+}


### PR DESCRIPTION
## Summary
- recognize `build.kotlin.annotations.Disabled` to skip tests
- hide disabled tests unless `--verbose` and print as DISABLED
- show disabled test count in summary
- test new behavior

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687f4ef1cc488320be7333d257517593