### PR TITLE
Enforce Unit return type for test functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ QuickTestRunner is a simple tool for executing small test files called `test.kts
 
 A `test.kts` file contains only top level Kotlin **functions**. Each function is treated as an
 individual unit test. Files are compiled using the embedded Kotlin compiler and executed
-within the same JVM – the `.kts` extension is only a name and no Kotlin scripting
-frameworks are used.
+within the same JVM – the `.kts` extension is only a name and no Kotlin scripting frameworks are used. Test functions must have block bodies and may not declare a return type – they are always `Unit` functions.
 
 ## Usage
 
@@ -24,8 +23,9 @@ the report will be an HTML file.
 
 The program recursively searches the provided directory for every `test.kts` file,
 compiles them and runs all top level functions. Any other top level declarations
-will cause the test run to fail. A test passes if it completes without
-throwing an exception.
+will cause the test run to fail. A test passes if it completes without throwing
+an exception. Functions that declare a return type or use expression bodies are
+rejected.
 
 ### Using the fat jar
 

--- a/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunner.kt
+++ b/src/main/kotlin/community/kotlin/unittesting/quicktest/QuickTestRunner.kt
@@ -266,5 +266,15 @@ private fun validateTestFile(file: File) {
             val names = invalid.joinToString(", ") { it::class.simpleName ?: "unknown" }
             throw IllegalArgumentException("test.kts may only contain top-level functions. Found: $names")
         }
+
+        val nonUnit = topLevel.filterIsInstance<KtNamedFunction>().filter {
+            it.typeReference != null || !it.hasBlockBody()
+        }
+        if (nonUnit.isNotEmpty()) {
+            val names = nonUnit.joinToString(", ") { it.name ?: "<anonymous>" }
+            throw IllegalArgumentException(
+                "test.kts functions must not declare return types and must use block bodies. Offending functions: $names"
+            )
+        }
     }
 }

--- a/src/test/kotlin/community/kotlin/unittesting/quicktest/ReturnTypeValidationTest.kt
+++ b/src/test/kotlin/community/kotlin/unittesting/quicktest/ReturnTypeValidationTest.kt
@@ -1,0 +1,19 @@
+package org.example
+
+import community.kotlin.unittesting.quicktest.QuickTestRunner
+import community.kotlin.unittesting.quicktest.TestStatus
+import community.kotlin.unittesting.quicktest.workspace
+import kotlin.test.*
+import java.io.File
+
+class ReturnTypeValidationTest {
+    @Test
+    fun functionsWithReturnTypesFail() {
+        val root = File("src/test/resources/ExampleProjectWithReturnType")
+        val results = QuickTestRunner()
+            .workspace(root)
+            .run()
+        val failures = results.getResults(TestStatus.FAILURE)
+        assertTrue(failures.isNotEmpty(), "Expected failure due to function return type")
+    }
+}

--- a/src/test/resources/ExampleProjectWithReturnType/test.kts
+++ b/src/test/resources/ExampleProjectWithReturnType/test.kts
@@ -1,0 +1,9 @@
+@file:WithArtifact("org.jsoup:jsoup:1.21.1")
+
+import org.jsoup.Jsoup
+import build.kotlin.withartifact.WithArtifact
+
+fun jsoupTest(): Int {
+    Jsoup.parse("<p>Hello</p>")
+    return 1
+}


### PR DESCRIPTION
## Summary
- check that kts test functions have block bodies and no return type
- document the new rule in README
- add failing example project with return type
- test validation logic with new unit test

## Testing
- `./gradlew test --no-daemon` *(fails: Could not determine the dependencies of task ':test'. Cannot find a Java installation matching: {languageVersion=17, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}...)*

------
https://chatgpt.com/codex/tasks/task_e_687fcba6c6b483209a1e588955c7d6d5